### PR TITLE
Bots now have a unique id for clients to keep track of the same bots between turns

### DIFF
--- a/server/bot.rb
+++ b/server/bot.rb
@@ -3,14 +3,15 @@ require_relative 'constants.rb'
 
 # The class that all bots are created with. Has all the methods that a client could be able to call
 class Bot < Entity
-  attr_reader :team, :vision
+  attr_reader :team, :vision, :uid
 
   # Class initializer
   # team = the team number of the bot
   # x = starting x position
   # y = starting y position
-  def initialize (team, x, y)
+  def initialize (team, x, y, uid)
     @team = team
+    @uid = uid
 
     angle = 90
     if @team == 1

--- a/server/connection.rb
+++ b/server/connection.rb
@@ -61,6 +61,7 @@ class Connection
   # bot = the bot object who's turn it is
   def send_data (bot)
     data = Hash.new
+    data["uid"] = bot.uid
     data["x"] = bot.x
     data["y"] = bot.y
     data["angle"] = bot.angle

--- a/server/map.rb
+++ b/server/map.rb
@@ -7,10 +7,11 @@ require_relative 'constants.rb'
 
 # The map class that controls all map operations
 class Map
-  attr_reader :map_array, :map_changes, :bots, :flags, :walls
+  attr_reader :map_array, :map_changes, :bots, :flags, :walls, :num_bots
 
   # Class initializer
   def initialize
+    @num_bots = 0
     @map_array = generate_map
     @map_changes = Array.new
   end
@@ -35,6 +36,12 @@ class Map
   # returns a flag
   def get_flag (team_number)
     @flags[team_number - 1]  #team 1 -> 0
+  end
+
+  # Gets the next uid for a bot
+  def next_bot_uid
+    @num_bots += 1
+    return @num_bots
   end
 
   # Get all entities (including air), that surronds a point
@@ -261,8 +268,8 @@ class Map
 
     i = 0
     while i < $NUM_BOTS
-      bots[0][i] = Bot.new(1, (i + 1) * $BOT_SPACING, $BOT_SPACING - 2)
-      bots[1][i] = Bot.new(2, ((i + 1) * $BOT_SPACING) + 2, $MAP_HEIGHT - $BOT_SPACING)
+      bots[0][i] = Bot.new(1, (i + 1) * $BOT_SPACING, $BOT_SPACING - 2, next_bot_uid)
+      bots[1][i] = Bot.new(2, ((i + 1) * $BOT_SPACING) + 2, $MAP_HEIGHT - $BOT_SPACING, next_bot_uid)
 
       map[bots[0][i].y][bots[0][i].x] = bots[0][i]
       map[bots[1][i].y][bots[1][i].x] = bots[1][i]

--- a/server/team.rb
+++ b/server/team.rb
@@ -103,7 +103,7 @@ class Team
   # Spawns a new bot
   # map = the global map object
   def spawn_bot (x, y, bot, map)
-    new_bot = Bot.new(@number, bot.x + x, bot.y + y)
+    new_bot = Bot.new(@number, bot.x + x, bot.y + y, map.next_botuid)
     @bots << new_bot
     map.set(new_bot.x, new_bot.y, new_bot)
     map.bots << new_bot


### PR DESCRIPTION
Before there was no way of telling how many bots your team had out or telling which bots were which. You also couldn't tell if a bot died. This fixes that issue by giving every bot a unique integer. This is uid given to the clients so they can tell which bot they are currently controlling.
